### PR TITLE
Add Git Hash and build Date/Time to the description block.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,7 @@ set(EMsoft_VER_MINOR "3")
 set(EMsoft_VER_PATCH "0")
 #------------------------------------------------------------------------------
 
-
 project (EMsoft LANGUAGES C CXX Fortran VERSION ${EMsoft_VER_MAJOR}.${EMsoft_VER_MINOR}.${EMsoft_VER_PATCH}.0)
-
 
 include(CMakeParseArguments)
 
@@ -187,6 +185,16 @@ cmpRevisionString( GENERATED_HEADER_FILE_PATH "${EMsoft_VERSION_HDR_FILE}"
                         NAMESPACE "EMsoft"
                         PROJECT_NAME "${PROJECT_NAME}"
                         EXPORT_MACRO "EMsoft_EXPORT")
+
+
+execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --verify HEAD
+                          OUTPUT_VARIABLE EMsoft_GIT_HASH
+                          RESULT_VARIABLE did_run
+                          ERROR_VARIABLE git_error
+                          WORKING_DIRECTORY ${EMsoft_SOURCE_DIR}
+                          OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+string(TIMESTAMP EMsoft_BUILD_TIMESTAMP "%Y-%m-%d %H:%M:%SZ" UTC)
 
 include (${CMP_SOURCE_DIR}/cmpProject.cmake)
 

--- a/Source/EMsoftLib/local.f90.in
+++ b/Source/EMsoftLib/local.f90.in
@@ -368,7 +368,7 @@ end function EMsoft_getEMsoftTestingPath
 !
 !> @author Marc De Graef, Carnegie Mellon University
 !
-!> @brief returns the EMsoftplatform
+!> @brief returns the Version Information
 !
 !> @param no input parameters
 !
@@ -384,6 +384,53 @@ character(20) :: version
 version = "@EMsoft_VER_MAJOR@_@EMsoft_VER_MINOR@_@EMsoft_VER_PATCH@_@EMsoft_VERSION_TWEAK@"
 
 end function EMsoft_getEMsoftversion
+
+
+!--------------------------------------------------------------------------
+!
+! FUNCTION: EMsoft_getEMsoftRevision
+!
+!> @author 
+!
+!> @brief returns the Git Hash of the current commit.
+!
+!> @param no input parameters
+!
+!> @date  
+!--------------------------------------------------------------------------
+recursive function EMsoft_getEMsoftRevision() result(revision)
+!DEC$ ATTRIBUTES DLLEXPORT :: EMsoft_getEMsoftRevision
+
+IMPLICIT NONE
+
+character(40) :: revision
+
+revision = "@EMsoft_GIT_HASH@"
+
+end function EMsoft_getEMsoftRevision
+
+!--------------------------------------------------------------------------
+!
+! FUNCTION: EMsoft_getEMsoftBuildDate
+!
+!> @author 
+!
+!> @brief returns the Git Hash of the current commit.
+!
+!> @param no input parameters
+!
+!> @date  
+!--------------------------------------------------------------------------
+recursive function EMsoft_getEMsoftBuildDate() result(buildDate)
+!DEC$ ATTRIBUTES DLLEXPORT :: EMsoft_getEMsoftBuildDate
+
+IMPLICIT NONE
+
+character(24) :: buildDate
+
+buildDate = "@EMsoft_BUILD_TIMESTAMP@"
+
+end function EMsoft_getEMsoftBuildDate
 
 
 !--------------------------------------------------------------------------
@@ -1230,7 +1277,9 @@ end if
  write (std,"(1x,'Program name         : ',A)") trim(progname)
  write (std,"(1x,'Purpose              : ',A)") trim(progdesc)
  write (std,"(1x,'Platform             : ',A)") "@CMAKE_SYSTEM_NAME@"
- write (std,"(1x,'Source code version  : ',A/)") trim(EMsoft_getEMsoftversion())
+ write (std,"(1x,'Source code version  : ',A)") trim(EMsoft_getEMsoftversion())
+ write (std,"(1x,'Source code Revision : ',A)") trim(EMsoft_getEMsoftRevision())
+ write (std,"(1x,'Build Date/Time      : ',A/)") trim(EMsoft_getEMsoftBuildDate())
 
  write (std,"(1x,'See https://github.com/EMsoft-org/EMsoft/wiki for selected help pages.'/)")
 


### PR DESCRIPTION
New output description block looks like this:
    Program name         : EMOpenCLinfo.f90
    Purpose              : List OpenCL platform and device information
    Platform             : Darwin
    Source code version  : 4_3_0_0
    Source code Revision : b5af2419b74e4eabfef9eada8f2e3922d233b64a
    Build Date/Time      : 2019-06-03 14:08:54Z

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>