### PR TITLE
Fix getting refined Euler angles from dp file

### DIFF
--- a/Source/DictionaryIndexing/EMgetANG.f90
+++ b/Source/DictionaryIndexing/EMgetANG.f90
@@ -139,7 +139,7 @@ call h5open_EMsoft(hdferr)
                                     getPhi1=.TRUE., &
                                     getPhi=.TRUE., &
                                     getPhi2=.TRUE.) 
-
+        refined = .TRUE.
     else
         call readEBSDDotProductFile(enl%dotproductfile, dinl, hdferr, EBSDDIdata, &
                                 getCI=.TRUE., &


### PR DESCRIPTION
Got only original Euler angles from dot product file even though `angledataset` was set to `refined` in the nml file since `refined` variable was not set to true. This is now fixed.

Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>