### PR TITLE
multiple updates

### DIFF
--- a/Source/EMsoftHDFLib/EBSDmod.f90
+++ b/Source/EMsoftHDFLib/EBSDmod.f90
@@ -103,7 +103,8 @@ IMPLICIT NONE
 type(EBSDNameListType),INTENT(INOUT)    :: enl
 !f2py intent(in,out) ::  enl
 integer(kind=irg),INTENT(OUT)           :: numangles
-type(EBSDAngleType),pointer             :: angles
+type(EBSDAngleType),INTENT(INOUT)       :: angles
+!f2py intent(in,out) ::  angles
 logical,INTENT(IN),OPTIONAL             :: verbose
 
 integer(kind=irg)                       :: io_int(1), i
@@ -213,7 +214,8 @@ IMPLICIT NONE
 type(EBSDFullNameListType),INTENT(INOUT):: enl
 !f2py intent(in,out) ::  enl
 integer(kind=irg),INTENT(OUT)           :: numangles
-type(EBSDAngleType),pointer             :: angles
+type(EBSDAngleType),INTENT(INOUT)       :: angles
+!f2py intent(in,out) ::  angles
 logical,INTENT(IN),OPTIONAL             :: verbose
 
 integer(kind=irg)                       :: io_int(1), i
@@ -314,7 +316,8 @@ IMPLICIT NONE
 type(EBSDNameListType),INTENT(INOUT)    :: enl
 !f2py intent(in,out) ::  enl
 integer(kind=irg),INTENT(OUT)           :: numangles
-type(EBSDAnglePCDefType),pointer        :: orpcdef
+type(EBSDAnglePCDefType),INTENT(INOUT)  :: orpcdef
+!f2py intent(in,out) ::  orpcdef
 logical,INTENT(IN),OPTIONAL             :: verbose
 
 integer(kind=irg)                       :: io_int(1), i

--- a/Source/pyEMsoft/kind_map
+++ b/Source/pyEMsoft/kind_map
@@ -49,6 +49,7 @@
 'integer': {'c_int32_t': 'int',
   			    'c_int64_t': 'long_long',
   			    'irg': 'int',
+			   '': 'int',
   			    'ish': 'short',
   			    'ill': 'long_long',
 				'HID_T':'int',

--- a/Source/pyEMsoft/run_pyEMsoft.sh
+++ b/Source/pyEMsoft/run_pyEMsoft.sh
@@ -54,6 +54,7 @@ declare -a f90_source_files=("io.f90"
                              "CLsupport.f90" 
                              "constants.f90" 
                              "math.f90"
+                             "rng.f90"
                              "typedefs.f90"
                              "crystal.f90" 
                              "symmetry.f90" 
@@ -64,9 +65,12 @@ declare -a f90_source_files=("io.f90"
                              "rotations.f90"
                              "diffraction.f90"
                              "so3.f90"
+                             "noise.f90"
                              "dictmod.f90"
+                             "filters.f90"
+                             "fftw3mod.f90"
                              "NameListTypedefs.f90"
-                             "NameListHandlers.f90") 
+                             "NameListHandlers.f90")
 
 declare -a f90_HDF_source_files=("commonmod.f90"
                                  "HDFsupport.f90"
@@ -120,13 +124,15 @@ done
 #=======================
 # execute the f90wrap program using all the files just copied
 echo " run_pyEMsoft.sh: executing f90wrap"
-f90wrap -k ${pyEMsoft_folder}/kind_map -m pyEMsoft ${f90_generated_source_files[*]} ${f90_source_files[*]} ${f90_HDF_source_files[*]} 1>build.log 2>build_error.log 
+f90wrap -k ${pyEMsoft_folder}/kind_map -m pyEMsoft ${f90_generated_source_files[*]} ${f90_source_files[*]} ${f90_HDF_source_files[*]} \
+--skip hipassfilterc 1>build.log 2>build_error.log 
 
 #=======================
 # call f2py-f90wrap to build the wrapper library
 echo " run_pyEMsoft.sh: executing f2py-f90wrap ... this can take a very long time (>1 hour) ..."
 f2py-f90wrap -c -m _pyEMsoft f90wrap_*.f90 -I${EMsoftBuildLib}  \
 -I${EMsoftBuildHDFLib} \
+-I$EMsoft_SDK/hdf5-1.8.20-Release/include/static \
 -I$EMsoft_SDK/CLFortran-0.0.1-Release/include \
 -I$EMsoft_SDK/jsonfortran-4.2.1-Release/include \
 -I$EMsoft_SDK/fftw-3.3.8/include \
@@ -134,8 +140,13 @@ f2py-f90wrap -c -m _pyEMsoft f90wrap_*.f90 -I${EMsoftBuildLib}  \
 -L$EMsoft_SDK/jsonfortran-4.2.1-Release/lib \
 -L$EMsoft_SDK/CLFortran-0.0.1-Release/lib \
 -L$EMsoft_SDK/fftw-3.3.8/lib \
+-L$EMsoft_SDK/hdf5-1.8.20-Release/lib \
 -L$CondaLib \
--lblas -llapack -lEMsoftLib -lEMsoftHDFLib -ljsonfortran -lhdf5 -lclfortran -lfftw3  1>>build.log 2>>build_error.log
+--link-lapack_opt \
+-lgomp -lpthread -lomp \
+-lEMsoftLib -lEMsoftHDFLib -ljsonfortran -lhdf5 -lhdf5_fortran \
+-lclfortran -lfftw3 -lhdf5_cpp -lhdf5_f90cstub -lhdf5_hl_cpp \
+-lhdf5_tools -lhdf5_hl -lhdf5_hl_fortran -lhdf5_hl_f90cstub  1>>build.log 2>>build_error.log
 
 #=======================
 # clean up all the .f90 files that we no longer need


### PR DESCRIPTION

1) EBSDmod (pointer type changed to intent(inout)) to include the EBSDreadangles routine
2) new kind added for the integer type from rng.f90 file
3) added: --link-lapack_opt
link optimal lapack in the system (currently its libmkl_rt.dylib in my system, part of anaconda).
If user is running pyEMsoft build without the anaconda environment, this will automatically link to the Accelerate Framework. this should also work for linux system
4) link to libomp.dylib and libgomp.1.dylib (part of anaconda dynamic libraries) for use in commonmod.f90. haven't found them in the other folders except for anaconda/lib. 
5. unable to use the highpassfilterC in filters.f90 so currently just skipped using the --skip+rountine name
6. link the hdf5 libraries! now we can read/save .xtal crystal data and .h5 master pattern files (including MC data), and read Euler angle lists from text file. 

EMsoft Compilation tested, pyEMsoft module build tested, unittests done.