### PR TITLE
icosahedral QC + rotations module

### DIFF
--- a/Source/EMsoftHDFLib/ECPmod.f90
+++ b/Source/EMsoftHDFLib/ECPmod.f90
@@ -1795,6 +1795,7 @@ end subroutine ECPIndexingGetWeightFactors
 !
 !> @date 01/26/16 MDG 1.0 original version
 !> @date 01/26/16 SS  1.1 corrected path; changed name
+!> @date 10/28/19 SS  1.2 added checking axial symmetry of 0 for iQCs
 !--------------------------------------------------------------------------
 recursive function GetPointGroup(xtalname,NoHDFInterfaceOpen,sgnumber) result(pgnum) &
 bind(c, name = 'GetPointGroup')
@@ -1866,8 +1867,10 @@ dataset = SC_AxialSymmetry
       pgnum = 35
     else if(naxis .eq. 12) then
       pgnum = 36
+    else if(naxis .eq. 0) then
+      pgnum = 33 ! icosahedral case with special reserved 0 axial symmetry
     else
-      call FatalError('GetPointGroup','unknown 2D quasicrystal symmetry in '//trim(filename))
+      call FatalError('GetPointGroup','unknown quasicrystal symmetry in '//trim(filename))
     end if
 
   else

--- a/Source/EMsoftHDFLib/InitializersQCHDF.f90
+++ b/Source/EMsoftHDFLib/InitializersQCHDF.f90
@@ -207,6 +207,9 @@ end subroutine Save2DQCDataHDF
 !> @param existingHDFhead (optional) if present, then use this as HDF_head
 !
 !> @date    06/25/18 SS 1.0 original, adapted from SaveDataHDF
+!> @date    10/28/19 SS 1.1 added Axial Symmetry for icosahedral QCs
+!                           axial symmetry = 0 will be reserved for 
+!                           icosahedral case
 !--------------------------------------------------------------------------
 recursive subroutine Save3DQCDataHDF(cell, existingHDFhead)
 !DEC$ ATTRIBUTES DLLEXPORT :: Save3DQCDataHDF
@@ -230,6 +233,7 @@ integer(kind=irg)                       :: hdferr
 real(kind=dbl)                          :: cellparams(3)
 integer(kind=irg),allocatable           :: atomtypes(:)
 real(kind=sgl),allocatable              :: atompos(:,:)
+integer(kind=irg)                       :: naxial
 logical                                 :: openHDFfile
 
 openHDFfile = .TRUE.
@@ -285,6 +289,15 @@ call HDFerror_check('SaveDataHDF:HDF_writeDatasetDoubleArray1D:'//trim(dataset),
 dataset = SC_SpaceGroupNumber
 hdferr = HDF_writeDatasetInteger(dataset, cell%SYM_SGnum, HDF_head)
 call HDFerror_check('SaveDataHDF:HDF_writeDatasetInteger:'//trim(dataset), hdferr)
+
+! the axial symmetry will be used to differentiate between QCs and regular crystals
+! for the 2D QCs, the axial symmetry will be equal to the axial symmetry along the 
+! periodic direction. for icosahedral QCs, this will be set to 0, which will be 
+! reserved for this case. this is done for minimum code change for dictionary indexing
+! of iQCs.
+dataset = SC_AxialSymmetry 
+naxial = 0
+hdferr = HDF_writeDatasetInteger(dataset, naxial, HDF_head)
 
 dataset = SC_Natomtypes
 hdferr = HDF_writeDatasetInteger(dataset, cell%ATOM_ntype, HDF_head)

--- a/Source/EMsoftLib/rotations.f90
+++ b/Source/EMsoftLib/rotations.f90
@@ -6175,9 +6175,11 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = om2ax(o)
+res = eu2ex(om2eu(o))
 
-res = ax(1:3) * ax(4)
+!ax = om2ax(o)
+
+!res = ax(1:3) * ax(4)
 
 end function om2ex
 
@@ -6206,9 +6208,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = om2ax(o)
+res = eu2ex(om2eu(o))
+!ax = om2ax(o)
 
-res = ax(1:3) * ax(4)
+!res = ax(1:3) * ax(4)
 
 end function om2ex_d
 
@@ -6299,9 +6302,11 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = qu2ax(q)
+res = eu2ex(qu2eu(q))
 
-res = ax(1:3) * ax(4)
+! ax = qu2ax(q)
+
+! res = ax(1:3) * ax(4)
 
 end function qu2ex
 
@@ -6330,9 +6335,11 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = qu2ax(q)
+res = eu2ex(qu2eu(q))
 
-res = ax(1:3) * ax(4)
+! ax = qu2ax(q)
+
+! res = ax(1:3) * ax(4)
 
 end function qu2ex_d
 
@@ -6508,7 +6515,7 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = cu2ax(h)
+ax = ho2ax(h)
 
 res = ax(1:3) * ax(4)
 
@@ -6604,7 +6611,7 @@ real(kind=dbl), parameter       :: tol = 1.0D-10
 
 an = NORM2(e)
 
-if(abs(an) .gt. tol) then
+if(an .gt. tol) then
         n = e / an
 else
         n = (/0.0, 0.0, 1.0/)
@@ -6642,7 +6649,7 @@ real(kind=dbl), parameter       :: tol = 1.0D-10
 
 an = NORM2(e)
 
-if(abs(an) .gt. tol) then
+if(an .gt. tol) then
         n = e / an
 else
         n = (/0.0, 0.0, 1.0/)

--- a/Source/EMsoftLib/rotations.f90
+++ b/Source/EMsoftLib/rotations.f90
@@ -167,6 +167,11 @@ interface st_check
         module procedure st_check_d
 end interface 
 
+public :: ex_check
+interface ex_check
+        module procedure ex_check
+        module procedure ex_check_d
+end interface 
 !--------------------------------
 ! general rotation creation routine, to make sure that a rotation representation is 
 ! correctly initialized, takes an axis and an angle as input, returns an orientationtype structure
@@ -235,6 +240,13 @@ interface eu2st
         module procedure eu2st_d
 end interface
 
+! convert Euler angles to exponential map
+public :: eu2ex
+interface eu2ex
+        module procedure eu2ex
+        module procedure eu2ex_d
+end interface
+
 !--------------------------------
 ! convert 3x3 orientation matrix to Euler angles
 public :: om2eu
@@ -283,6 +295,13 @@ public :: om2st
 interface om2st
         module procedure om2st
         module procedure om2st_d
+end interface
+
+! convert rotation matrix to exponential map
+public :: om2ex
+interface om2ex
+        module procedure om2ex
+        module procedure om2ex_d
 end interface
 
 !--------------------------------
@@ -335,6 +354,13 @@ interface ax2st
         module procedure ax2st_d
 end interface
 
+! convert axis angle pair to exponential map
+public :: ax2ex
+interface ax2ex
+        module procedure ax2ex
+        module procedure ax2ex_d
+end interface
+
 !--------------------------------
 ! convert Rodrigues vector to Euler angles
 public :: ro2eu
@@ -383,6 +409,13 @@ public :: ro2st
 interface ro2st
         module procedure ro2st
         module procedure ro2st_d
+end interface
+
+! convert Rodrigues vector to exponential map
+public :: ro2ex
+interface ro2ex
+        module procedure ro2ex
+        module procedure ro2ex_d
 end interface
 
 !--------------------------------
@@ -435,6 +468,13 @@ interface qu2st
         module procedure qu2st_d
 end interface
 
+! convert quaternion to exponential map
+public :: qu2ex
+interface qu2ex
+        module procedure qu2ex
+        module procedure qu2ex_d
+end interface
+
 !--------------------------------
 ! convert homochoric to euler
 public :: ho2eu
@@ -483,6 +523,13 @@ public :: ho2st
 interface ho2st
         module procedure ho2st
         module procedure ho2st_d
+end interface
+
+! convert homochoric to exponential map
+public :: ho2ex
+interface ho2ex
+        module procedure ho2ex
+        module procedure ho2ex_d
 end interface
 
 !--------------------------------
@@ -535,6 +582,13 @@ interface cu2st
         module procedure cu2st_d
 end interface
 
+! convert cubochoric to exponential map
+public :: cu2ex
+interface cu2ex
+        module procedure cu2ex
+        module procedure cu2ex_d
+end interface
+
 !--------------------------------
 ! convert stereographic to euler
 public :: st2eu
@@ -583,6 +637,70 @@ public :: st2cu
 interface st2cu
         module procedure st2cu
         module procedure st2cu_d
+end interface
+
+! convert stereographic to exponential map
+public :: st2ex
+interface st2ex
+        module procedure st2ex
+        module procedure st2ex_d
+end interface
+
+!-----------------------------------
+! exponential map to axis-angle pair
+public :: ex2ax
+interface ex2ax
+        module procedure ex2ax
+        module procedure ex2ax_d
+end interface
+
+! exponential map to quaternion
+public :: ex2qu
+interface ex2qu
+        module procedure ex2qu
+        module procedure ex2qu_d
+end interface
+
+! exponential map to euler
+public :: ex2eu
+interface ex2eu
+        module procedure ex2eu
+        module procedure ex2eu_d
+end interface
+
+! exponential map to rodrigues vector
+public :: ex2ro
+interface ex2ro
+        module procedure ex2ro
+        module procedure ex2ro_d
+end interface
+
+! exponential map to orientation matrix
+public :: ex2om
+interface ex2om
+        module procedure ex2om
+        module procedure ex2om_d
+end interface
+
+! exponential map to cubochoric vector
+public :: ex2cu
+interface ex2cu
+        module procedure ex2cu
+        module procedure ex2cu_d
+end interface
+
+! exponential map to stereographic vector
+public :: ex2st
+interface ex2st
+        module procedure ex2st
+        module procedure ex2st_d
+end interface
+
+! exponential map to homochoric vector
+public :: ex2ho
+interface ex2ho
+        module procedure ex2ho
+        module procedure ex2ho_d
 end interface
 
 !--------------------------------
@@ -1363,6 +1481,84 @@ res = 0
 end function om_check_d
 
 !--------------------------------------------------------------------------
+!
+! Function: ex_check
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief verify that the exponentioal map has magnitude in range [0, pi]
+!
+!> @param ex 3-component vector (single precision)  
+!>  
+! 
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex_check(ex) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex_check
+
+use local
+use constants
+use error
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: ex(3)
+
+integer(kind=irg)               :: res
+real(kind=dbl)                  :: r
+real(kind=dbl), parameter       :: eps = 1.e-15
+
+res = 1
+
+r = NORM2(ex)
+if ((r - cPi) .ge. eps) then
+   call FatalError('rotations:ex_check_d','magnitude must be in range [0,pi]')
+endif
+
+res = 0
+
+end function ex_check
+
+!--------------------------------------------------------------------------
+!
+! Function: ex_check_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief verify that the exponentioal map has magnitude in range [0, pi]
+!
+!> @param ex 3-component vector (double precision)  
+!>  
+! 
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex_check_d(ex) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex_check_d
+
+use local
+use constants
+use error
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: ex(3)
+
+integer(kind=irg)               :: res
+real(kind=dbl)                  :: r
+real(kind=dbl), parameter       :: eps = 1.e-15
+
+res = 1
+
+r = NORM2(ex)
+if ((r - cPi) .ge. eps) then
+   call FatalError('rotations:ex_check_d','magnitude must be in range [0,pi]')
+endif
+
+res = 0
+
+end function ex_check_d
+
+!--------------------------------------------------------------------------
 !--------------------------------------------------------------------------
 ! here we start with a series of input routines
 !--------------------------------------------------------------------------
@@ -1515,6 +1711,7 @@ select case (intype)
                 res%homochoric = eu2ho(orient(1:3))
                 res%cubochoric = eu2cu(orient(1:3))
                 res%stereographic = eu2st(orient(1:3))
+                res%expomap = eu2ex(orient(1:3))
         case ('ro')     ! Rodrigues vector
                 ! verify the Rodrigues-Frank vector; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1528,6 +1725,7 @@ select case (intype)
                 res%homochoric = ro2ho(orient(1:4))
                 res%cubochoric = ro2cu(orient(1:4))
                 res%stereographic = ro2st(orient(1:4))
+                res%expomap = ro2ex(orient(1:4))
         case ('ho')     ! homochoric
                 ! verify the homochoric vector; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1541,6 +1739,7 @@ select case (intype)
                 res%quat = ho2qu(orient(1:3))
                 res%cubochoric = ho2cu(orient(1:3))
                 res%stereographic = ho2st(orient(1:3))
+                res%expomap = ho2ex(orient(1:3))
         case ('cu')     ! cubochoric
                 ! verify the cubochoric vector; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1554,6 +1753,7 @@ select case (intype)
                 res%axang = cu2ax(orient(1:3))
                 res%rodrigues = cu2ro(orient(1:3))
                 res%stereographic = cu2st(orient(1:3))
+                res%expomap = cu2ex(orient(1:3))
         case ('st')     ! stereographic
                 ! verify the cstereographic vector; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1567,6 +1767,7 @@ select case (intype)
                 res%quat = st2qu(orient(1:3))
                 res%axang = st2ax(orient(1:3))
                 res%rodrigues = st2ro(orient(1:3))
+                res%expomap = st2ex(orient(1:3))
         case ('qu')     ! quaternion
                 ! verify the quaternion; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1580,6 +1781,7 @@ select case (intype)
                 res%homochoric = qu2ho(orient(1:4))
                 res%cubochoric = qu2cu(orient(1:4))
                 res%stereographic = qu2st(orient(1:4))
+                res%expomap = qu2ex(orient(1:4))
         case ('ax')     ! axis angle pair
                 ! verify the axis angle pair; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1593,6 +1795,22 @@ select case (intype)
                 res%homochoric = ax2ho(orient(1:4))
                 res%cubochoric = ax2cu(orient(1:4))
                 res%stereographic = ax2st(orient(1:4))
+                res%expomap = ax2ex(orient(1:4))
+        case('ex')      ! exponential map
+                ! verify the exponential map; this will abort program if values are outside range
+                if (present(rotcheck)) then 
+                        if (rotcheck.eqv..TRUE.) i = qu_check(orient)
+                endif
+                res%expomap = orient(1:3)
+                res%stereographic = ex2st(orient(1:3))
+                res%cubochoric = ex2cu(orient(1:3))
+                res%homochoric = ex2ho(orient(1:3))
+                res%eulang = ex2eu(orient(1:3))
+                res%om = ex2om(orient(1:3))
+                res%quat = ex2qu(orient(1:3))
+                res%axang = ex2ax(orient(1:3))
+                res%rodrigues = ex2ro(orient(1:3))
+                
 end select 
 
 end function init_orientation
@@ -1643,6 +1861,7 @@ select case (intype)
                 res%homochoric = eu2ho_d(orient(1:3))
                 res%cubochoric = eu2cu_d(orient(1:3))
                 res%stereographic = eu2st_d(orient(1:3))
+                res%expomap = eu2ex_d(orient(1:3))
         case ('ro')     ! Rodrigues vector
                 ! verify the Rodrigues-Frank vector; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1656,6 +1875,7 @@ select case (intype)
                 res%homochoric = ro2ho_d(orient(1:4))
                 res%cubochoric = ro2cu_d(orient(1:4))
                 res%stereographic = ro2st_d(orient(1:4))
+                res%expomap = ro2ex_d(orient(1:4))
         case ('ho')     ! homochoric
                 ! verify the homochoric vector; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1669,6 +1889,7 @@ select case (intype)
                 res%quat = ho2qu_d(orient(1:3))
                 res%cubochoric = ho2cu_d(orient(1:3))
                 res%stereographic = ho2st_d(orient(1:3))
+                res%expomap = ho2ex_d(orient(1:4))
         case ('cu')     ! cubochoric
                 ! verify the cubochoric vector; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1682,6 +1903,7 @@ select case (intype)
                 res%axang = cu2ax_d(orient(1:3))
                 res%rodrigues = cu2ro_d(orient(1:3))
                 res%stereographic = cu2st_d(orient(1:3))
+                res%expomap = cu2ex_d(orient(1:3))
         case ('st')     ! stereographic
                 ! verify the cstereographic vector; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1695,6 +1917,7 @@ select case (intype)
                 res%quat = st2qu_d(orient(1:3))
                 res%axang = st2ax_d(orient(1:3))
                 res%rodrigues = st2ro_d(orient(1:3))
+                res%expomap = st2ex_d(orient(1:3))
         case ('qu')     ! quaternion
                 ! verify the quaternion; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1708,6 +1931,7 @@ select case (intype)
                 res%homochoric = qu2ho_d(orient(1:4))
                 res%cubochoric = qu2cu_d(orient(1:4))
                 res%stereographic = qu2st(orient(1:4))
+                res%expomap = qu2ex_d(orient(1:4))
         case ('ax')     ! axis angle pair
                 ! verify the axis angle pair; this will abort program if values are outside range
                 if (present(rotcheck)) then 
@@ -1721,6 +1945,21 @@ select case (intype)
                 res%homochoric = ax2ho_d(orient(1:4))
                 res%cubochoric = ax2cu_d(orient(1:4))
                 res%stereographic = ax2st_d(orient(1:4))
+                res%expomap = ax2ex_d(orient(1:4))
+        case('ex')      ! exponential map
+                ! verify the exponential map; this will abort program if values are outside range
+                if (present(rotcheck)) then 
+                        if (rotcheck.eqv..TRUE.) i = qu_check(orient)
+                endif
+                res%expomap = orient(1:3)
+                res%stereographic = ex2st_d(orient(1:3))
+                res%cubochoric = ex2cu_d(orient(1:3))
+                res%homochoric = ex2ho_d(orient(1:3))
+                res%eulang = ex2eu_d(orient(1:3))
+                res%om = ex2om_d(orient(1:3))
+                res%quat = ex2qu_d(orient(1:3))
+                res%axang = ex2ax_d(orient(1:3))
+                res%rodrigues = ex2ro_d(orient(1:3))
 end select  
 
 end function init_orientation_d
@@ -1768,6 +2007,7 @@ select case (intype)
                 res%homochoric = om2ho(orient)
                 res%stereographic = om2st(orient)
                 res%cubochoric = om2cu(orient)
+                res%expomap = om2ex(orient)
 end select 
 
 end function init_orientation_om
@@ -1816,6 +2056,7 @@ select case (intype)
                 res%homochoric = om2ho_d(orient)
                 res%stereographic = om2st_d(orient)
                 res%cubochoric = om2cu_d(orient)
+                res%expomap = om2ex_d(orient)
 end select 
 
 end function init_orientation_om_d
@@ -5847,6 +6088,947 @@ end if
 
 end function st2cu_d
 
+!--------------------------------------------------------------------------
+!
+! Function: eu2ex
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief Euler angles to exponential map 
+!
+!> @param e 3 Euler angles in radians (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function eu2ex(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: eu2ex
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: e(3)         !< input Euler angles in radians
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = eu2ax(e)
+
+res = ax(1:3) * ax(4)
+
+end function eu2ex
+
+!--------------------------------------------------------------------------
+!
+! Function: eu2ex_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief Euler angles to exponential map 
+!
+!> @param e 3 Euler angles in radians (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function eu2ex_d(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: eu2ex_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: e(3)         !< input Euler angles in radians
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = eu2ax(e)
+
+res = ax(1:3) * ax(4)
+
+end function eu2ex_d
+
+!--------------------------------------------------------------------------
+!
+! Function: om2ex
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief rotation matrix to exponential map 
+!
+!> @param  o 3x3 rotation matrix (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function om2ex(o) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: om2ex
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: o(3,3)        
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = om2ax(o)
+
+res = ax(1:3) * ax(4)
+
+end function om2ex
+
+!--------------------------------------------------------------------------
+!
+! Function: om2ex_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief rotation matrix to exponential map 
+!
+!> @param o 3x3 rotation matrix (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function om2ex_d(o) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: om2ex_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: o(3,3)       
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = om2ax(o)
+
+res = ax(1:3) * ax(4)
+
+end function om2ex_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ro2ex
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief rodrigues vector to exponential map 
+!
+!> @param r rodrigues vector (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ro2ex(r) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ro2ex
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: r(4)         
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = ro2ax(r)
+
+res = ax(1:3) * ax(4)
+
+end function ro2ex
+
+!--------------------------------------------------------------------------
+!
+! Function: ro2ex_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief rodrigues vector to exponential map 
+!
+!> @param r rodrigues vector (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ro2ex_d(r) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ro2ex_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: r(4)         
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = ro2ax(r)
+
+res = ax(1:3) * ax(4)
+
+end function ro2ex_d
+
+!--------------------------------------------------------------------------
+!
+! Function: qu2ex
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief quaternion to exponential map 
+!
+!> @param q quaternion (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function qu2ex(q) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: qu2ex
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: q(4)         
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = qu2ax(q)
+
+res = ax(1:3) * ax(4)
+
+end function qu2ex
+
+!--------------------------------------------------------------------------
+!
+! Function: qu2ex_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief quaternion to exponential map 
+!
+!> @param q quaternion (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function qu2ex_d(q) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: qu2ex_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: q(4)         
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = qu2ax(q)
+
+res = ax(1:3) * ax(4)
+
+end function qu2ex_d
+
+!--------------------------------------------------------------------------
+!
+! Function: cu2ex
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief cubochoric vector to exponential map 
+!
+!> @param c cubochoric vector (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function cu2ex(c) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: cu2ex
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: c(3)        
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = cu2ax(c)
+
+res = ax(1:3) * ax(4)
+
+end function cu2ex
+
+!--------------------------------------------------------------------------
+!
+! Function: cu2ex_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief cubochoric vector to exponential map 
+!
+!> @param c cubochoric vector (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function cu2ex_d(c) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: cu2ex_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: c(3)         
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = cu2ax(c)
+
+res = ax(1:3) * ax(4)
+
+end function cu2ex_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ax2ex
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief axis angle pair to exponential map 
+!
+!> @param a axis angle pair (single precision)
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ax2ex(a) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ax2ex
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: a(4)        
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+res = a(1:3) * a(4)
+
+end function ax2ex
+
+!--------------------------------------------------------------------------
+!
+! Function: ax2ex_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief axis angle to exponential map 
+!
+!> @param a axis angle pair (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ax2ex_d(a) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ax2ex_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: a(4)         
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+res = a(1:3) * a(4)
+
+end function ax2ex_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ho2ex
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief homochoric vector to exponential map 
+!
+!> @param h homochoric vector (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ho2ex(h) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ho2ex
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: h(3)         
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = ho2ax(h)
+
+res = ax(1:3) * ax(4)
+
+end function ho2ex
+
+!--------------------------------------------------------------------------
+!
+! Function: ho2ex_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief homochoric vector to exponential map 
+!
+!> @param h homochoric vector (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ho2ex_d(h) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ho2ex_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: h(3)        
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = cu2ax(h)
+
+res = ax(1:3) * ax(4)
+
+end function ho2ex_d
+
+!--------------------------------------------------------------------------
+!
+! Function: st2ex
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief stereographic vector to exponential map 
+!
+!> @param s stereographic vector (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function st2ex(s) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: st2ex
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: s(3)         
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = st2ax(s)
+
+res = ax(1:3) * ax(4)
+
+end function st2ex
+
+!--------------------------------------------------------------------------
+!
+! Function: st2ex_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief stereographic vector to exponential map 
+!
+!> @param s stereographic vector (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function st2ex_d(s) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: st2ex_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: s(3)         
+real(kind=dbl)                  :: res(3)       !< output exponential map
+
+real(kind=dbl)                  :: ax(4)
+
+ax = st2ax(s)
+
+res = ax(1:3) * ax(4)
+
+end function st2ex_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2ax
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to axis angle pair 
+!
+!> @param e exponential map (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2ax(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2ax
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: e(3)         !< input exponential map     
+real(kind=dbl)                  :: res(4)       !< output axis angle pair
+
+real(kind=dbl)                  :: an, n(3)
+real(kind=dbl), parameter       :: tol = 1.0D-10
+
+an = NORM2(e)
+
+if(abs(an) .gt. tol) then
+        n = e / an
+else
+        n = (/0.0, 0.0, 1.0/)
+end if
+
+res = (/n, an/)
+
+end function ex2ax
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2ax_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to axis angle pair 
+!
+!> @param e exponential map (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2ax_d(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2ax_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: e(3)         !< input exponential map
+real(kind=dbl)                  :: res(4)       !< output exponential map
+
+real(kind=dbl)                  :: an, n(3)
+real(kind=dbl), parameter       :: tol = 1.0D-10
+
+an = NORM2(e)
+
+if(abs(an) .gt. tol) then
+        n = e / an
+else
+        n = (/0.0, 0.0, 1.0/)
+end if
+
+res = (/n, an/)
+
+end function ex2ax_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2om
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to rotation matrix
+!
+!> @param e exponential map (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2om(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2om
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: e(3)         !< input exponential map     
+real(kind=dbl)                  :: res(3,3)     !< output rotation matrix
+
+res = ax2om(ex2ax(e))
+
+end function ex2om
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2om_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to rotation matrix
+!
+!> @param e exponential map (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2om_d(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2om_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: e(3)         !< input exponential map
+real(kind=dbl)                  :: res(3,3)     !< output rotation matrix
+
+res = ax2om(ex2ax(e))
+
+end function ex2om_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2eu
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to euler angles in radians
+!
+!> @param e exponential map (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2eu(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2eu
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: e(3)         !< input exponential map     
+real(kind=dbl)                  :: res(3)       !< output euler angles in radians
+
+res = ax2eu(ex2ax(e))
+
+end function ex2eu
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2eu_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to euler angles in radians
+!
+!> @param e exponential map (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2eu_d(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2eu_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: e(3)         !< input exponential map
+real(kind=dbl)                  :: res(3)       !< output euler angles in radians
+
+res = ax2eu(ex2ax(e))
+
+end function ex2eu_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2qu
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to quaternion
+!
+!> @param e exponential map (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2qu(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2qu
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: e(3)         !< input exponential map     
+real(kind=dbl)                  :: res(4)       !< output quaternion
+
+res = ax2qu(ex2ax(e))
+
+end function ex2qu
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2qu_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to quaternion
+!
+!> @param e exponential map (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2qu_d(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2qu_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: e(3)         !< input exponential map
+real(kind=dbl)                  :: res(4)       !< output quaternion
+
+res = ax2qu(ex2ax(e))
+
+end function ex2qu_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2ro
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to rodrigues vector
+!
+!> @param e exponential map (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2ro(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2ro
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: e(3)         !< input exponential map     
+real(kind=dbl)                  :: res(4)       !< output rodrigues vector
+
+res = ax2ro(ex2ax(e))
+
+end function ex2ro
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2ro_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to rodrigues vector
+!
+!> @param e exponential map (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2ro_d(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2ro_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: e(3)         !< input exponential map
+real(kind=dbl)                  :: res(4)       !< output rodrigues vector
+
+res = ax2ro(ex2ax(e))
+
+end function ex2ro_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2cu
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to cubochoric vector
+!
+!> @param e exponential map (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2cu(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2cu
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: e(3)         !< input exponential map     
+real(kind=dbl)                  :: res(3)       !< output cubochoric vector
+
+res = ax2cu(ex2ax(e))
+
+end function ex2cu
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2cu_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to cubochoric vector
+!
+!> @param e exponential map (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2cu_d(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2cu_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: e(3)         !< input exponential map
+real(kind=dbl)                  :: res(3)       !< output cubochoric vector
+
+res = ax2cu(ex2ax(e))
+
+end function ex2cu_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2ho
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to homochoric vector
+!
+!> @param e exponential map (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2ho(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2ho
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: e(3)         !< input exponential map     
+real(kind=dbl)                  :: res(3)       !< output homochoric vector
+
+res = ax2ho(ex2ax(e))
+
+end function ex2ho
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2ho_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to homochoric vector
+!
+!> @param e exponential map (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2ho_d(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2ho_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: e(3)         !< input exponential map
+real(kind=dbl)                  :: res(3)       !< output homochoric vector
+
+res = ax2ho(ex2ax(e))
+
+end function ex2ho_d
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2st
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to stereographic vector
+!
+!> @param e exponential map (single precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2st(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2st
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=sgl),INTENT(IN)       :: e(3)         !< input exponential map     
+real(kind=dbl)                  :: res(3)       !< output stereographic vector
+
+res = ax2st(ex2ax(e))
+
+end function ex2st
+
+!--------------------------------------------------------------------------
+!
+! Function: ex2st_d
+!
+!> @author Saransh Singh, Lawrence Livermore National Lab
+!
+!> @brief exponential map to stereographic vector
+!
+!> @param e exponential map (double precision)  
+!>  
+!> @date 10/25/19   SS 1.0 original
+!--------------------------------------------------------------------------
+recursive function ex2st_d(e) result(res)
+!DEC$ ATTRIBUTES DLLEXPORT :: ex2st_d
+
+use local
+use constants
+
+IMPLICIT NONE
+
+real(kind=dbl),INTENT(IN)       :: e(3)         !< input exponential map
+real(kind=dbl)                  :: res(3)       !< output stereographic vector
+
+res = ax2st(ex2ax(e))
+
+end function ex2st_d
 
 !--------------------------------------------------------------------------
 !--------------------------------------------------------------------------
@@ -6256,6 +7438,10 @@ if (present(outtype)) then
           ioreal(1:3) = o%stereographic
           call WriteValue(trim(pret)//'Stereographic                       : ', ioreal, 3, "(3(F8.4,' '))")
 
+        case ('ex')
+          ioreal(1:3) = o%expomap
+          call WriteValue(trim(pret)//'Exponential Map                      : ', ioreal, 3, "(3(F8.4,' '))")
+
         case ('om')
           ioreal(1:3) = o%om(1,1:3)
           call WriteValue('                                       / ', ioreal, 3, "(2(F8.4,' '),F8.4,' \')")
@@ -6287,6 +7473,8 @@ else
   call WriteValue(trim(pret)//'Quaternion                       : ', ioreal, 4, "(4(F8.4,' '))")
   ioreal(1:3) = o%stereographic
   call WriteValue(trim(pret)//'Stereographic                       : ', ioreal, 3, "(3(F8.4,' '))")
+  ioreal(1:3) = o%expomap
+  call WriteValue(trim(pret)//'Exponential Map                       : ', ioreal, 3, "(3(F8.4,' '))")
   ioreal(1:3) = o%om(1,1:3)
   call WriteValue('                                   / ', ioreal, 3, "(2(F8.4,' '),F8.4,' \')")
   ioreal(1:3) = o%om(2,1:3)
@@ -6368,6 +7556,10 @@ if (present(outtype)) then
           ioreal(1:3) = o%stereographic
           call WriteValue(trim(pret)//'Stereographic                       : ', ioreal, 3, "(3(F8.4,' '))")
 
+        case ('ex')
+          ioreal(1:3) = o%expomap
+          call WriteValue(trim(pret)//'Exponential Map                      : ', ioreal, 3, "(3(F8.4,' '))")
+
         case ('om')
           ioreal(1:3) = o%om(1,1:3)
           call WriteValue('                                       / ', ioreal, 3, "(2(F8.4,' '),F8.4,' \')")
@@ -6399,6 +7591,8 @@ else
   call WriteValue(trim(pret)//'Quaternion                       : ', ioreal, 4, "(4(F12.7,' '))")
   ioreal(1:3) = o%stereographic
   call WriteValue(trim(pret)//'Stereographic                       : ', ioreal, 3, "(3(F8.4,' '))")
+  ioreal(1:3) = o%expomap
+  call WriteValue(trim(pret)//'Exponential Map                       : ', ioreal, 3, "(3(F8.4,' '))")
   ioreal(1:3) = o%om(1,1:3)
   call WriteValue('                                   / ', ioreal, 3, "(2(F8.4,' '),F8.4,' \')")
   ioreal(1:3) = o%om(2,1:3)

--- a/Source/EMsoftLib/rotations.f90
+++ b/Source/EMsoftLib/rotations.f90
@@ -6175,11 +6175,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-res = eu2ex(om2eu(o))
+res = qu2ex(om2qu(o))
+! ax = om2ax(o)
 
-!ax = om2ax(o)
-
-!res = ax(1:3) * ax(4)
+! res = ax(1:3) * ax(4)
 
 end function om2ex
 
@@ -6208,10 +6207,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-res = eu2ex(om2eu(o))
-!ax = om2ax(o)
+res = qu2ex(om2qu(o))
+! ax = om2ax(o)
 
-!res = ax(1:3) * ax(4)
+! res = ax(1:3) * ax(4)
 
 end function om2ex_d
 
@@ -6240,9 +6239,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = ro2ax(r)
+res = eu2ex(ro2eu(r))
+!ax = ro2ax(r)
 
-res = ax(1:3) * ax(4)
+!res = ax(1:3) * ax(4)
 
 end function ro2ex
 
@@ -6271,9 +6271,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = ro2ax(r)
+res = eu2ex(ro2eu(r))
+! ax = ro2ax(r)
 
-res = ax(1:3) * ax(4)
+! res = ax(1:3) * ax(4)
 
 end function ro2ex_d
 
@@ -6368,9 +6369,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = cu2ax(c)
+res = eu2ex(cu2eu(c))
+! ax = cu2ax(c)
 
-res = ax(1:3) * ax(4)
+! res = ax(1:3) * ax(4)
 
 end function cu2ex
 
@@ -6399,9 +6401,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = cu2ax(c)
+res = eu2ex(cu2eu(c))
+! ax = cu2ax(c)
 
-res = ax(1:3) * ax(4)
+! res = ax(1:3) * ax(4)
 
 end function cu2ex_d
 
@@ -6427,6 +6430,8 @@ IMPLICIT NONE
 
 real(kind=sgl),INTENT(IN)       :: a(4)        
 real(kind=dbl)                  :: res(3)       !< output exponential map
+integer(kind=irg)               :: ii, ctr
+real(kind=sgl),parameter        :: thr = 1.0E-6
 
 res = a(1:3) * a(4)
 
@@ -6454,6 +6459,8 @@ IMPLICIT NONE
 
 real(kind=dbl),INTENT(IN)       :: a(4)         
 real(kind=dbl)                  :: res(3)       !< output exponential map
+integer(kind=irg)               :: ii, ctr
+real(kind=sgl),parameter        :: thr = 1.0D-8
 
 res = a(1:3) * a(4)
 
@@ -6484,9 +6491,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = ho2ax(h)
+res = eu2ex(ho2eu(h))
+! ax = ho2ax(h)
 
-res = ax(1:3) * ax(4)
+! res = ax(1:3) * ax(4)
 
 end function ho2ex
 
@@ -6515,9 +6523,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = ho2ax(h)
+res = eu2ex(ho2eu(h))
+! ax = ho2ax(h)
 
-res = ax(1:3) * ax(4)
+! res = ax(1:3) * ax(4)
 
 end function ho2ex_d
 
@@ -6546,9 +6555,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = st2ax(s)
+res = eu2ex(st2eu(s))
+! ax = st2ax(s)
 
-res = ax(1:3) * ax(4)
+! res = ax(1:3) * ax(4)
 
 end function st2ex
 
@@ -6577,9 +6587,10 @@ real(kind=dbl)                  :: res(3)       !< output exponential map
 
 real(kind=dbl)                  :: ax(4)
 
-ax = st2ax(s)
+res = eu2ex(st2eu(s))
+! ax = st2ax(s)
 
-res = ax(1:3) * ax(4)
+! res = ax(1:3) * ax(4)
 
 end function st2ex_d
 

--- a/Source/EMsoftLib/typedefs.f90
+++ b/Source/EMsoftLib/typedefs.f90
@@ -1377,6 +1377,7 @@ type orientationtype
   real(kind=sgl)        :: homochoric(3)        ! homochoric representation according to Frank's paper  
   real(kind=sgl)        :: cubochoric(3)        ! cubic grid representation (derived from homochoric)
   real(kind=sgl)        :: stereographic(3)     ! 3D stereographic  [added 10/05/17]
+  real(kind=sgl)        :: expomap(3)           ! exponential map [added 10/25/19]
 end type orientationtype
 
 
@@ -1390,6 +1391,7 @@ type orientationtyped
   real(kind=dbl)        :: homochoric(3)        ! homochoric representation according to Frank's paper  
   real(kind=dbl)        :: cubochoric(3)        ! cubic grid representation (derived from homochoric)
   real(kind=dbl)        :: stereographic(3)     ! 3D stereographic  [added 10/05/17]
+  real(kind=dbl)        :: expomap(3)           ! exponential map [added 10/25/19]
 end type orientationtyped
 
 !--------------------------------------------------------------------------

--- a/Source/Test/MODRotationsTest.f90
+++ b/Source/Test/MODRotationsTest.f90
@@ -39,6 +39,7 @@
 !> The current source code was generated on Fri Oct 27 12:32:32 2017
 ! 
 !> @date 10/27/17 MDG 1.0 original
+!> @date 10/29/19 SS  1.1 added tests for exponential map
 !--------------------------------------------------------------------------
 module MODRotationsTest
 
@@ -62,7 +63,7 @@ IMPLICIT NONE
 integer(C_INT32_T),INTENT(OUT)  :: res
 
 real(kind=dbl)        :: ieu(3), oeu(3), iro(4), oro(4), iho(3), oho(3), icu(3), ocu(3), ist(3)
-real(kind=dbl)        :: iax(4), oax(4), iqu(4), oqu(4), ivec(3), ovec(3), ost(3)
+real(kind=dbl)        :: iax(4), oax(4), iqu(4), oqu(4), ivec(3), ovec(3), ost(3), iex(3), oex(3)
 real(kind=dbl)        :: iom(3,3), oom(3,3), omm(3,3), diff, diffmax, dtor, aux
 real(kind=dbl),parameter :: maxerr = 1.0D-9
 integer(kind=irg)     :: tcnt, i,  numarg, testcounter, testsfailed
@@ -1189,7 +1190,128 @@ testcounter = testcounter + 1
      return
   end if
  
+! adding all ex2xx-xx2ex tests where xx are all the other rotation representations 
+! already implemented [added 10/29/2019 by SS]
+
+testcounter = testcounter + 1
+  iex = ot%expomap
+  oex = eu2ex(ex2eu(iex))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)   write (*,*) 'ex2eu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
  
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : eu2ex-ex2eu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  iex = ot%expomap
+  oex = om2ex(ex2om(iex))
+
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)   write (*,*) 'ex2om max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : om2ex-ex2om ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  iex = ot%expomap
+  oex = ro2ex(ex2ro(iex))
+
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)   write (*,*) 'ex2ro max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ro2ex-ex2ro ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  iex = ot%expomap
+  oex = qu2ex(ex2qu(iex))
+
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)   write (*,*) 'ex2qu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : qu2ex-ex2qu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  iex = ot%expomap
+  oex = ax2ex(ex2ax(iex))
+
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)   write (*,*) 'ex2ax max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ax2ex-ex2ax ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  iex = ot%expomap
+  oex = ho2ex(ex2ho(iex))
+
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)   write (*,*) 'ex2ho max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ho2ex-ex2ho ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  iex = ot%expomap
+  oex = st2ex(ex2st(iex))
+
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)   write (*,*) 'ex2st max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : st2ex-ex2st ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  iex = ot%expomap
+  oex = cu2ex(ex2cu(iex))
+
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)   write (*,*) 'ex2cu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : cu2ex-ex2cu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
  if (verbose) write (*,*) ' Maximum difference in pairwise tests  : ', diffmax
  
  
@@ -7260,7 +7382,401 @@ testcounter = testcounter + 1
      return
   end if
  
+! adding all triple tests for exponential map
+! [added 10/29/19 by SS]
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = om2ex(eu2om(ex2eu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'om2ex-eu2om-ex2eu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
  
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : om2ex-eu2om-ex2eu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ro2ex(eu2ro(ex2eu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ro2ex-eu2ro-ex2eu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ro2ex-eu2ro-ex2eu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+ 
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = qu2ex(eu2qu(ex2eu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'qu2ex-eu2qu-ex2eu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : qu2ex-eu2qu-ex2eu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ax2ex(eu2ax(ex2eu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ax2ex-eu2ax-ex2eu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ax2ex-eu2ax-ex2eu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ho2ex(eu2ho(ex2eu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ho2ex-eu2ho-ex2eu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ho2ex-eu2ho-ex2eu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = st2ex(eu2st(ex2eu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'st2ex-eu2st-ex2eu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : st2ex-eu2st-ex2eu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = cu2ex(eu2cu(ex2eu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'cu2ex-eu2cu-ex2eu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : cu2ex-eu2cu-ex2eu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ro2ex(om2ro(ex2om(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ro2ex-om2ro-ex2om max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ro2ex-om2ro-ex2om ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = qu2ex(om2qu(ex2om(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'qu2ex-om2qu-ex2om max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : qu2ex-om2qu-ex2om ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ax2ex(om2ax(ex2om(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ax2ex-om2ax-ex2om max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ax2ex-om2ax-ex2om ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ho2ex(om2ho(ex2om(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ho2ex-om2ho-ex2om max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ho2ex-om2ho-ex2om ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = st2ex(om2st(ex2om(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'st2ex-om2st-ex2om max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : st2ex-om2st-ex2om ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = cu2ex(om2cu(ex2om(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'cu2ex-om2cu-ex2om max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : cu2ex-om2cu-ex2om ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = qu2ex(ro2qu(ex2ro(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'qu2ex-ro2qu-ex2ro max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : qu2ex-ro2qu-ex2ro ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ax2ex(ro2ax(ex2ro(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ax2ex-ro2ax-ex2ro max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ax2ex-ro2ax-ex2ro ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ho2ex(ro2ho(ex2ro(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ho2ex-ro2ho-ex2ro max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ho2ex-ro2ho-ex2ro ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = st2ex(ro2st(ex2ro(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'st2ex-ro2st-ex2ro max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : st2ex-ro2st-ex2ro ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = cu2ex(ro2cu(ex2ro(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'cu2ex-ro2cu-ex2ro max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : cu2ex-ro2cu-ex2ro ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ax2ex(qu2ax(ex2qu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ax2ex-qu2ax-ex2qu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ax2ex-qu2ax-ex2qu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ho2ex(qu2ho(ex2qu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ho2ex-qu2ho-ex2qu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ho2ex-qu2ho-ex2qu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = st2ex(qu2st(ex2qu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'st2ex-qu2st-ex2qu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : st2ex-qu2st-ex2qu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = cu2ex(qu2cu(ex2qu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'cu2ex-qu2cu-ex2qu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : cu2ex-qu2cu-ex2qu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ho2ex(ax2ho(ex2ax(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ho2ex-ax2ho-ex2ax max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ho2ex-ax2ho-ex2ax ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = st2ex(ax2st(ex2ax(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'st2ex-ax2st-ex2ax max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : st2ex-ax2st-ex2ax ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = cu2ex(ax2cu(ex2ax(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'cu2ex-ax2cu-ex2ax max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : cu2ex-ax2cu-ex2ax ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = st2ex(ho2st(ex2ho(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'st2ex-ho2st-ex2ho max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : st2ex-ho2st-ex2ho ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = cu2ex(ho2cu(ex2ho(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'cu2ex-ho2cu-ex2ho max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : cu2ex-ho2cu-ex2ho ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = cu2ex(st2cu(ex2st(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'cu2ex-st2cu-ex2st max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : cu2ex-st2cu-ex2st ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
  if (verbose) write (*,*) ' Maximum difference in triplet tests  : ', diffmax
 end do
 write (*,*) ' Total number of rotations tests executed = ',testcounter

--- a/Source/Test/MODRotationsTest.f90
+++ b/Source/Test/MODRotationsTest.f90
@@ -1193,10 +1193,12 @@ testcounter = testcounter + 1
 ! adding all ex2xx-xx2ex tests where xx are all the other rotation representations 
 ! already implemented [added 10/29/2019 by SS]
 
+if(verbose) write(6,*) 'ex test'
 testcounter = testcounter + 1
   iex = ot%expomap
   oex = eu2ex(ex2eu(iex))
-  diff = maxval(abs(oex-ot%expomap))
+  omm = ex2om(oex)
+  diff = maxval(abs(omm-ot%om))
   if (verbose)   write (*,*) 'ex2eu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -1210,7 +1212,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   iex = ot%expomap
   oex = om2ex(ex2om(iex))
-
+  print*,'iex = ',iex
+  print*,'oex = ',oex
   diff = maxval(abs(oex-ot%expomap))
   if (verbose)   write (*,*) 'ex2om max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )

--- a/Source/Test/MODRotationsTest.f90
+++ b/Source/Test/MODRotationsTest.f90
@@ -1197,6 +1197,7 @@ if(verbose) write(6,*) 'ex test'
 testcounter = testcounter + 1
   iex = ot%expomap
   oex = eu2ex(ex2eu(iex))
+
   omm = ex2om(oex)
   diff = maxval(abs(omm-ot%om))
   if (verbose)   write (*,*) 'ex2eu max st difference = ', diff
@@ -1212,13 +1213,13 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   iex = ot%expomap
   oex = om2ex(ex2om(iex))
-  print*,'iex = ',iex
-  print*,'oex = ',oex
-  diff = maxval(abs(oex-ot%expomap))
+
+  iom = ex2om(oex)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)   write (*,*) 'ex2om max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
-  if (diffmax.gt.maxerr) then 
+  if (diffmax.gt.maxerr) then
      testsfailed = testsfailed+1
      write (*,*) 'test # ',testcounter,' failed : om2ex-ex2om ',rots(1:3,i)
      res = testcounter
@@ -1229,7 +1230,8 @@ testcounter = testcounter + 1
   iex = ot%expomap
   oex = ro2ex(ex2ro(iex))
 
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(oex)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)   write (*,*) 'ex2ro max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -1244,7 +1246,8 @@ testcounter = testcounter + 1
   iex = ot%expomap
   oex = qu2ex(ex2qu(iex))
 
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(oex)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)   write (*,*) 'ex2qu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -1259,7 +1262,8 @@ testcounter = testcounter + 1
   iex = ot%expomap
   oex = ax2ex(ex2ax(iex))
 
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(oex)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)   write (*,*) 'ex2ax max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -1274,7 +1278,8 @@ testcounter = testcounter + 1
   iex = ot%expomap
   oex = ho2ex(ex2ho(iex))
 
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(oex)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)   write (*,*) 'ex2ho max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -1289,7 +1294,8 @@ testcounter = testcounter + 1
   iex = ot%expomap
   oex = st2ex(ex2st(iex))
 
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(oex)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)   write (*,*) 'ex2st max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -1304,7 +1310,8 @@ testcounter = testcounter + 1
   iex = ot%expomap
   oex = cu2ex(ex2cu(iex))
 
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(oex)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)   write (*,*) 'ex2cu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7391,7 +7398,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = om2ex(eu2om(ex2eu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'om2ex-eu2om-ex2eu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7405,7 +7413,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ro2ex(eu2ro(ex2eu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ro2ex-eu2ro-ex2eu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7419,7 +7428,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = qu2ex(eu2qu(ex2eu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'qu2ex-eu2qu-ex2eu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7433,7 +7443,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ax2ex(eu2ax(ex2eu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ax2ex-eu2ax-ex2eu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7447,7 +7458,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ho2ex(eu2ho(ex2eu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ho2ex-eu2ho-ex2eu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7461,7 +7473,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = st2ex(eu2st(ex2eu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'st2ex-eu2st-ex2eu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7475,7 +7488,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = cu2ex(eu2cu(ex2eu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'cu2ex-eu2cu-ex2eu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7489,7 +7503,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ro2ex(om2ro(ex2om(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ro2ex-om2ro-ex2om max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7503,7 +7518,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = qu2ex(om2qu(ex2om(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'qu2ex-om2qu-ex2om max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7517,7 +7533,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ax2ex(om2ax(ex2om(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ax2ex-om2ax-ex2om max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7531,7 +7548,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ho2ex(om2ho(ex2om(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ho2ex-om2ho-ex2om max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7545,7 +7563,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = st2ex(om2st(ex2om(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'st2ex-om2st-ex2om max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7559,7 +7578,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = cu2ex(om2cu(ex2om(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'cu2ex-om2cu-ex2om max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7573,7 +7593,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = qu2ex(ro2qu(ex2ro(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'qu2ex-ro2qu-ex2ro max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7587,7 +7608,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ax2ex(ro2ax(ex2ro(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ax2ex-ro2ax-ex2ro max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7601,7 +7623,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ho2ex(ro2ho(ex2ro(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ho2ex-ro2ho-ex2ro max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7615,7 +7638,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = st2ex(ro2st(ex2ro(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'st2ex-ro2st-ex2ro max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7629,7 +7653,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = cu2ex(ro2cu(ex2ro(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'cu2ex-ro2cu-ex2ro max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7643,7 +7668,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ax2ex(qu2ax(ex2qu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ax2ex-qu2ax-ex2qu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7657,7 +7683,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ho2ex(qu2ho(ex2qu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ho2ex-qu2ho-ex2qu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7671,7 +7698,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = st2ex(qu2st(ex2qu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'st2ex-qu2st-ex2qu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7685,7 +7713,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = cu2ex(qu2cu(ex2qu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'cu2ex-qu2cu-ex2qu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7699,7 +7728,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ho2ex(ax2ho(ex2ax(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ho2ex-ax2ho-ex2ax max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7713,7 +7743,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = st2ex(ax2st(ex2ax(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'st2ex-ax2st-ex2ax max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7727,7 +7758,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = cu2ex(ax2cu(ex2ax(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'cu2ex-ax2cu-ex2ax max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7741,7 +7773,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = st2ex(ho2st(ex2ho(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'st2ex-ho2st-ex2ho max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7755,7 +7788,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = cu2ex(ho2cu(ex2ho(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'cu2ex-ho2cu-ex2ho max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7769,7 +7803,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = cu2ex(st2cu(ex2st(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'cu2ex-st2cu-ex2st max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7783,7 +7818,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = eu2ex(om2eu(ex2om(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'eu2ex-om2eu-ex2om max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7797,7 +7833,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = eu2ex(ro2eu(ex2ro(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'eu2ex-ro2eu-ex2ro max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7811,7 +7848,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = om2ex(ro2om(ex2ro(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'om2ex-ro2om-ex2ro max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7825,7 +7863,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = eu2ex(qu2eu(ex2qu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'eu2ex-qu2eu-ex2qu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7839,7 +7878,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = om2ex(qu2om(ex2qu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'om2ex-qu2om-ex2qu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7853,7 +7893,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ro2ex(qu2ro(ex2qu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ro2ex-qu2ro-ex2qu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7867,7 +7908,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ro2ex(qu2ro(ex2qu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ro2ex-qu2ro-ex2qu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7881,7 +7923,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = eu2ex(ax2eu(ex2ax(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'eu2ex-ax2eu-ex2ax max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7895,7 +7938,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = om2ex(ax2om(ex2ax(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'om2ex-ax2om-ex2ax max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7909,7 +7953,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ro2ex(ax2ro(ex2ax(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ro2ex-ax2ro-ex2ax max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7923,7 +7968,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = qu2ex(ax2qu(ex2ax(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'qu2ex-ax2qu-ex2ax max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7937,7 +7983,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = eu2ex(ho2eu(ex2ho(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'eu2ex-ho2eu-ex2ho max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7951,7 +7998,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = om2ex(ho2om(ex2ho(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'om2ex-ho2om-ex2ho max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7965,7 +8013,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ro2ex(ho2ro(ex2ho(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ro2ex-ho2ro-ex2ho max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7979,7 +8028,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = qu2ex(ho2qu(ex2ho(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'qu2ex-ho2qu-ex2ho max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -7993,7 +8043,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ax2ex(ho2ax(ex2ho(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ax2ex-ho2ax-ex2ho max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8007,7 +8058,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = eu2ex(st2eu(ex2st(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'eu2ex-st2eu-ex2st max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8021,7 +8073,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = om2ex(st2om(ex2st(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'om2ex-st2om-ex2st max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8035,7 +8088,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ro2ex(st2ro(ex2st(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ro2ex-st2ro-ex2st max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8049,7 +8103,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = qu2ex(st2qu(ex2st(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'qu2ex-st2qu-ex2st max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8063,7 +8118,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ax2ex(st2ax(ex2st(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ax2ex-st2ax-ex2st max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8077,7 +8133,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ho2ex(st2ho(ex2st(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ho2ex-st2ho-ex2st max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8091,7 +8148,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = eu2ex(cu2eu(ex2cu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'eu2ex-cu2eu-ex2cu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8105,7 +8163,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = om2ex(cu2om(ex2cu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'om2ex-cu2om-ex2cu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8119,7 +8178,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ro2ex(cu2ro(ex2cu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ro2ex-cu2ro-ex2cu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8133,7 +8193,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = qu2ex(cu2qu(ex2cu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'qu2ex-cu2qu-ex2cu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8147,7 +8208,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ax2ex(cu2ax(ex2cu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ax2ex-cu2ax-ex2cu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8161,7 +8223,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = ho2ex(cu2ho(ex2cu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'ho2ex-cu2ho-ex2cu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  
@@ -8175,7 +8238,8 @@ testcounter = testcounter + 1
 testcounter = testcounter + 1
   ist = ot%expomap
   ost = st2ex(cu2st(ex2cu(iex)))
-  diff = maxval(abs(oex-ot%expomap))
+  iom = ex2om(ost)
+  diff = maxval(abs(iom-ot%om))
   if (verbose)  write (*,*) 'st2ex-cu2st-ex2cu max st difference = ', diff
   diffmax = maxval( (/ diffmax,diff /) )
  

--- a/Source/Test/MODRotationsTest.f90
+++ b/Source/Test/MODRotationsTest.f90
@@ -7777,6 +7777,412 @@ testcounter = testcounter + 1
      return
   end if
 
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = eu2ex(om2eu(ex2om(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'eu2ex-om2eu-ex2om max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : eu2ex-om2eu-ex2om ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = eu2ex(ro2eu(ex2ro(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'eu2ex-ro2eu-ex2ro max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : eu2ex-ro2eu-ex2ro ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = om2ex(ro2om(ex2ro(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'om2ex-ro2om-ex2ro max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : om2ex-ro2om-ex2ro ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = eu2ex(qu2eu(ex2qu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'eu2ex-qu2eu-ex2qu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : eu2ex-qu2eu-ex2qu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = om2ex(qu2om(ex2qu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'om2ex-qu2om-ex2qu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : om2ex-qu2om-ex2qu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ro2ex(qu2ro(ex2qu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ro2ex-qu2ro-ex2qu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ro2ex-qu2ro-ex2qu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ro2ex(qu2ro(ex2qu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ro2ex-qu2ro-ex2qu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ro2ex-qu2ro-ex2qu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = eu2ex(ax2eu(ex2ax(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'eu2ex-ax2eu-ex2ax max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : eu2ex-ax2eu-ex2ax ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = om2ex(ax2om(ex2ax(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'om2ex-ax2om-ex2ax max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : om2ex-ax2om-ex2ax ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ro2ex(ax2ro(ex2ax(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ro2ex-ax2ro-ex2ax max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ro2ex-ax2ro-ex2ax ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = qu2ex(ax2qu(ex2ax(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'qu2ex-ax2qu-ex2ax max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : qu2ex-ax2qu-ex2ax ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = eu2ex(ho2eu(ex2ho(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'eu2ex-ho2eu-ex2ho max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : eu2ex-ho2eu-ex2ho ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = om2ex(ho2om(ex2ho(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'om2ex-ho2om-ex2ho max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : om2ex-ho2om-ex2ho ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ro2ex(ho2ro(ex2ho(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ro2ex-ho2ro-ex2ho max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ro2ex-ho2ro-ex2ho ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = qu2ex(ho2qu(ex2ho(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'qu2ex-ho2qu-ex2ho max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : qu2ex-ho2qu-ex2ho ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ax2ex(ho2ax(ex2ho(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ax2ex-ho2ax-ex2ho max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ax2ex-ho2ax-ex2ho ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = eu2ex(st2eu(ex2st(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'eu2ex-st2eu-ex2st max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : eu2ex-st2eu-ex2st ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = om2ex(st2om(ex2st(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'om2ex-st2om-ex2st max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : om2ex-st2om-ex2st ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ro2ex(st2ro(ex2st(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ro2ex-st2ro-ex2st max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ro2ex-st2ro-ex2st ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = qu2ex(st2qu(ex2st(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'qu2ex-st2qu-ex2st max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : qu2ex-st2qu-ex2st ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ax2ex(st2ax(ex2st(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ax2ex-st2ax-ex2st max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ax2ex-st2ax-ex2st ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ho2ex(st2ho(ex2st(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ho2ex-st2ho-ex2st max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ho2ex-st2ho-ex2st ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = eu2ex(cu2eu(ex2cu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'eu2ex-cu2eu-ex2cu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : eu2ex-cu2eu-ex2cu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = om2ex(cu2om(ex2cu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'om2ex-cu2om-ex2cu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : om2ex-cu2om-ex2cu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ro2ex(cu2ro(ex2cu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ro2ex-cu2ro-ex2cu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ro2ex-cu2ro-ex2cu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = qu2ex(cu2qu(ex2cu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'qu2ex-cu2qu-ex2cu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : qu2ex-cu2qu-ex2cu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ax2ex(cu2ax(ex2cu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ax2ex-cu2ax-ex2cu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ax2ex-cu2ax-ex2cu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = ho2ex(cu2ho(ex2cu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'ho2ex-cu2ho-ex2cu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : ho2ex-cu2ho-ex2cu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
+testcounter = testcounter + 1
+  ist = ot%expomap
+  ost = st2ex(cu2st(ex2cu(iex)))
+  diff = maxval(abs(oex-ot%expomap))
+  if (verbose)  write (*,*) 'st2ex-cu2st-ex2cu max st difference = ', diff
+  diffmax = maxval( (/ diffmax,diff /) )
+ 
+  if (diffmax.gt.maxerr) then 
+     testsfailed = testsfailed+1
+     write (*,*) 'test # ',testcounter,' failed : st2ex-cu2st-ex2cu ',rots(1:3,i)
+     res = testcounter
+     return
+  end if
+
  if (verbose) write (*,*) ' Maximum difference in triplet tests  : ', diffmax
 end do
 write (*,*) ' Total number of rotations tests executed = ',testcounter


### PR DESCRIPTION
1. added reserved axial symmetry of 0 to *.qxtal hdf5 file for icosahedral QCs. This allows indexing of QCs with minimum change in code. Updated the GetPoints subroutine in ECPmod to set pgnum=33 for iQCs.

2. Added exponential map (ex) as another rotation representation. All conversion routines ex2yy and yy2ex in single and double precision and all tests in MODROtationsTest. Compilation and testing done on OSX.