### PR TITLE
Lzw decompression bugfix

### DIFF
--- a/Source/EMsoftLib/lzw.f90
+++ b/Source/EMsoftLib/lzw.f90
@@ -219,7 +219,8 @@ contains
                this%dict%bits-this%bitsLeft-8) ! mask off middle/trailing bits and shift
     code = ior(b0,b1)
     if(this%bitsLeft.le.(this%dict%bits-9)) then ! code is split across 3 instead of 2 bytes
-      b2 = ishft(iand(this%encoded(this%index+2),magicBytes(8+this%dict%bits-this%bitsLeft)),this%dict%bits-this%bitsLeft-16) ! mask off middle/trailing bits and shift
+      b2 = ishft(iand(int(this%encoded(this%index+2),int16),magicBytes(8+this%dict%bits-this%bitsLeft)),&
+                 this%dict%bits-this%bitsLeft-16) ! mask off middle/trailing bits and shift
       code = ior(code,b2)
       this%index = this%index + 1
       this%bitsLeft = 16 - this%dict%bits + this%bitsLeft


### PR DESCRIPTION
Got this error while building EMsoft after updating to Ubuntu 19.10:

```bash
> cmake -DCMAKE_BUILD_TYPE=Debug -DEMsoft_SDK=/home/hakon/kode/emsoft/EMsoft_SDK -DEMsoft_ENABLE_EMsoftWorkbench=OFF -S /home/hakon/kode/emsoft/EMsoft -B .
# [...]
> make -j4
Scanning dependencies of target EMsoftLib_Generate_StringConstants
Scanning dependencies of target EMsoftLib_Cpp
Scanning dependencies of target DIWorkflowTestPrep
Scanning dependencies of target EMsoftLib_C
[  1%] Generating StringConstants files....
# [...]
[  3%] Built target EMsoftLib_Cpp
Scanning dependencies of target EMsoftLib
[  4%] Building Fortran object EMsoftLib/CMakeFiles/EMsoftLib.dir/stringconstants.f90.o
# [...]
[  4%] Building Fortran object EMsoftLib/CMakeFiles/EMsoftLib.dir/lzw.f90.o
/home/hakon/kode/emsoft/EMsoft/Source/EMsoftLib/lzw.f90:222:22:

  222 |       b2 = ishft(iand(this%encoded(this%index+2),magicBytes(8+this%dict%bits-this%bitsLeft)),this%dict%bits-this%bitsLeft-16) ! mask off middle/trailing bits and shift
      |                      1
Error: Arguments of ‘iand’ have different kind type parameters at (1)
[  5%] Building Fortran object EMsoftLib/CMakeFiles/EMsoftLib.dir/random.f90.o
make[2]: *** [EMsoftLib/CMakeFiles/EMsoftLib.dir/build.make:531: EMsoftLib/CMakeFiles/EMsoftLib.dir/lzw.f90.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:1474: EMsoftLib/CMakeFiles/EMsoftLib.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
```

Looked into `lzw.f90` and saw some changes applied to two of three similar lines... After applying the changes to the last line it built OK. Hence this PR. 