### PR TITLE
Provide support for bool type in C

### DIFF
--- a/Source/EMsoftWrapperLib/DictionaryIndexing/EMsoftDIwrappers.h
+++ b/Source/EMsoftWrapperLib/DictionaryIndexing/EMsoftDIwrappers.h
@@ -1,6 +1,8 @@
 #ifndef _emsoft_DIwrappers_H_
 #define _emsoft_DIwrappers_H_
-
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Changes are made in EMsoft/Source/EMsoftWrapperLib/DictionaryIndexing/EMsoftDIwrappers.h to provide support for bool type in C.