### PR TITLE
fix data type of ipar, consistent with EMDIwrappermod.f90

### DIFF
--- a/Source/EMsoftWrapperLib/DictionaryIndexing/EMsoftDIwrappers.h
+++ b/Source/EMsoftWrapperLib/DictionaryIndexing/EMsoftDIwrappers.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -60,8 +61,7 @@ typedef void (*ProgCallBackTypeErrorDIdriver)(size_t, int);
 * @param object unique identifier for calling class instantiation
 * @param cancel boolean to trigger cancellation of computation
 */
-void EMsoftCpreprocessEBSDPatterns
-    (int32_t* ipar, float* fpar, char* spar, float* mask,
+void EMsoftCpreprocessEBSDPatterns(int32_t* ipar, float* fpar, char* spar, float* mask,
      float* exptIQ, float* ADPmap, ProgCallBackTypeDI2 callback, 
      size_t object, bool* cancel);
 
@@ -72,8 +72,7 @@ void EMsoftCpreprocessEBSDPatterns
 * @param inputpattern  input EBSD pattern as float array
 * @param outputpattern  input EBSD pattern as float array
 */
-void EMsoftCpreprocessSingleEBSDPattern
-    (size_t* ipar, float* fpar, float* inputpattern, float* outputpattern);
+void EMsoftCpreprocessSingleEBSDPattern(int32_t* ipar, float* fpar, float* inputpattern, float* outputpattern);
 
 /**
 * EBSD pattern preprocessing parameter range:
@@ -83,8 +82,7 @@ void EMsoftCpreprocessSingleEBSDPattern
 * @param averagedpattern  input EBSD pattern as float array
 * @param patternarray  input EBSD pattern as float array
 */
-void EMsoftCEBSDDIpreview
-    (size_t* ipar, float* fpar, char* spar, float* averagedpattern, float* patternarray);
+void EMsoftCEBSDDIpreview(int32_t* ipar, float* fpar, char* spar, float* averagedpattern, float* patternarray);
 
 /**
 * EBSD Dictionary indexing (all in ram) wrapper routine
@@ -101,10 +99,10 @@ void EMsoftCEBSDDIpreview
 * @param cancel boolean to trigger cancellation of computation
 */
 
-void EMsoftCEBSDDI
-	(int32_t* ipar, float* fpar, char* spar, float* dpatterns, float* epatterns, 
-	 float* resultmain, int32_t* indexmain, ProgCallBackTypeDI3 callback, ProgCallBackTypeError errorcallback,
-     size_t object, bool* cancel); 
+void EMsoftCEBSDDI(int32_t* ipar, float* fpar, char* spar, float* dpatterns, float* epatterns, 
+    float* resultmain, int32_t* indexmain, ProgCallBackTypeDI3 callback, ProgCallBackTypeError errorcallback,
+    size_t object, bool* cancel); 
+
 
 /**
 * EBSD indexing refinement (all in ram) wrapper routine
@@ -124,10 +122,9 @@ void EMsoftCEBSDDI
 * @param cancel boolean to trigger cancellation of computation
 */
 
-void EMsoftCEBSDRefine
-	(size_t* ipar, float* fpar, int32_t* accum_e, float* mLPNH, float* mLPSH,
-	 float* variants, float* epatterns, float* startEulers, float* startdps, float* eumain, 
-	 float* dpmain, ProgCallBackTypeDI2 callback, size_t object, bool* cancel);
+void EMsoftCEBSDRefine(int32_t* ipar, float* fpar, int32_t* accum_e, float* mLPNH, float* mLPSH,
+    float* variants, float* epatterns, float* startEulers, float* startdps, float* eumain, 
+    float* dpmain, ProgCallBackTypeDI2 callback, size_t object, bool* cancel);
 
 
 /**
@@ -141,10 +138,9 @@ void EMsoftCEBSDRefine
 * @param object unique identifier for calling class instantiation
 * @param cancel boolean to trigger cancellation of computation
 */
-void EBSDDIdriver
-    (char* nmlfile, char* progname, 
+void EBSDDIdriver(char* nmlfile, char* progname, 
      // float* dparray, int32_t* indexarray, 
-     ProgCallBackTypeDIdriver3 callback, 
+     ProgCallBackTypeDI3 callback, 
      ProgCallBackTypeErrorDIdriver errorcallback,
      size_t object, bool* cancel);
 


### PR DESCRIPTION
1. Fix data type of ipar in the header file (should be int32_t instead of size_t), as all ipar in EMDIwrappermod.f90 are of the type c_int32_t;
2. ProgCallBackTypeDIdriver3 is not defined, replaced with ProgCallBackTypeDI3.