### PR TITLE
Fixing CMake copy-paste error for MacOS.

### DIFF
--- a/Source/EMsoftWorkbench/Workbench/CMakeLists.txt
+++ b/Source/EMsoftWorkbench/Workbench/CMakeLists.txt
@@ -221,7 +221,7 @@ set(EXE_LINK_LIBRARIES
   )
 if(APPLE)
   set(EXE_LINK_LIBRARIES 
-    ${EMSOFT_hdf5LinkLibs} 
+    ${EXE_LINK_LIBRARIES} 
     ghcFilesystem::ghc_filesystem
   )
 endif()


### PR DESCRIPTION
Signed-off-by: Joey Kleingers <joey.kleingers@bluequartz.net>