### PR TITLE
Missing energy computation in MCfoil and MCxyz kernels ?

### DIFF
--- a/opencl/EMMC.cl
+++ b/opencl/EMMC.cl
@@ -222,7 +222,7 @@ __kernel void MC(__global float* Lamx, __global float* Lamy, const float E, cons
         c_new = c0;
         escape_depth = 0.0f;
         alpha = (3.4E-3f)*powr(z,0.66667f)/E_new;
-        sig_eNA = (5.21f * 602.2f)*z*z/E_new/E_new*4.0f*PI/alpha/(1.0f+alpha)*pow(E_new+511.0f,2.0f)/pow(E+1022.0f,2.0f);
+        sig_eNA = (5.21f * 602.2f)*z*z/E_new/E_new*4.0f*PI/alpha/(1.0f+alpha)*pow(E_new+511.0f,2.0f)/pow(E_new+1024.0f,2.0f);
 
         mfp = A * 1.0e7f/(rho*sig_eNA);
         step = -mfp * log(rand);
@@ -240,7 +240,7 @@ __kernel void MC(__global float* Lamx, __global float* Lamy, const float E, cons
 // Taken from book Monte Carlo simulation for Electron Microscopy and Microanalysis, David C. Joy
 
             alpha = (3.4e-3f)*powr(z,0.66667f)/E_new;
-            sig_eNA = (5.21f * 602.2f)*z*z/E_new/E_new*4.0f*PI/alpha/(1.0f+alpha)*pow(E_new+511.0f,2.0f)/pow(E+1022.0f,2.0f);
+            sig_eNA = (5.21f * 602.2f)*z*z/E_new/E_new*4.0f*PI/alpha/(1.0f+alpha)*pow(E_new+511.0f,2.0f)/pow(E_new+1024.0f,2.0f);
    	        mfp = A * 1.0e7f/(rho*sig_eNA);
 
             z11 = seeds[4*id];

--- a/opencl/EMMCfoil.cl
+++ b/opencl/EMMCfoil.cl
@@ -229,6 +229,10 @@ __kernel void MC(const float E, const int count, const float z, const float rho,
         step = -mfp * log(rand);
         r_new = r0 + step*c_new*1.0e7f;
         r0 = r_new;
+
+        de_ds = -0.00785f*(z/(A*E_new)) * log(1.166f*E_new/J + 0.9911f);
+        E_new += step*rho*de_ds;
+
         counter1 = 0;   // This is used as a counter for the number of monte carlo steps to carry out for each electron. This is due to the lock step nature of the GPU code. We have arbitrarily set this to a 300 or so, though this may be material dependent
         
         counter2 = 0;   // This counter is used to figure out if the electron has left the sample or not. Again, this is because of the lock step nature. All steps have to be executed on each thread irrespective of the fact that the electron may have actually left the sample

--- a/opencl/EMMCxyz.cl
+++ b/opencl/EMMCxyz.cl
@@ -228,6 +228,10 @@ __kernel void MCxyz(__global float* Lamx, __global float* Lamy, __global float* 
         r_new = r0 + step*c_new*1.0e7f;
         //r_new = (float4)(r0.x + step*c_new.x, r0.y + step*c_new.y, r0.z + step*c_new.z, 0.0f);
         r0 = r_new;
+
+        de_ds = -0.00785f*(z/(A*E_new)) * log(1.166f*E_new/J + 0.9911f);
+        E_new += step*rho*de_ds;
+        
         counter1 = 0;   // This is used as a counter for the number of monte carlo steps to carry out for each electron. This is due to the lock step nature of the GPU code. We have arbitrarily set this to a 1000, though this is material dependent
         
         counter2 = 0;   // This counter is used to figure out if the electron has left the sample or not. Again, this is because of the lock step nature. All steps have to be executed on each thread irrespective of the fact that the electron may have actually left the sample


### PR DESCRIPTION
Hi Marc,

New energy is not computed before while loop in MCfoil and MCxyz kernels compared to MC kernel. Is there any reason or is it a missing computation ?

Clément