### PR TITLE
Multithread emebsddi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ IDL/various
 /src_programs/*.c
 /src_programs/go*
 /manuals_todo/Eshelby
+Release*
+CMakeLists.txt

--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,3 @@ IDL/various
 /src_programs/go*
 /manuals_todo/Eshelby
 Release*
-CMakeLists.txt


### PR DESCRIPTION
Made some significant changes to the OpenMP layout, using SECTIONS (not Tasks) for the dp vs dictionary creation, and nested parallelization for the sort functions and dictionary creation.  Implementing this in a object oriented framework should make it even cleaner (think of putting all the stuff for one SECTION within a method call, each method call can have its own parallelization). 

Please test on your machines.  I have it running on my dataset, but that still takes 6.5 hours (which is way better than the  24h of the original).  Also I should note that my GPU (testing on my Mac with a relatively weak Radeon 580 Pro) is still only at 50% utilization. If this checks out, I may set up reading experimental patterns as a task while the results are sorting on the CPU to see if I can keep the GPU even more occupied. 